### PR TITLE
fix: `Cannot read property 'toString' of undefined ` error

### DIFF
--- a/src/services/devices-service.ts
+++ b/src/services/devices-service.ts
@@ -13,7 +13,7 @@ export class DevicesService {
 		device.model = this.getDeviceName(message);
 		device.name = message.name || device.model;
 		device.platform = message.platform;
-		device.previewAppVersion = message.friendlyVersion || message.version.toString();
+		device.previewAppVersion = message.friendlyVersion || (message.version ? message.version.toString() : null);
 		device.osVersion = `${isAndroid ? "Android" : "iOS"} ${message.osVersion}`;
 		device.plugins = this.getPlugins(message);
 		device.runtimeVersion = this.getRuntimeVersion(message);


### PR DESCRIPTION
It is possible a device without version property to be reported from pubnub. 
```
{ 
    deviceId: 'bc065520-718b-4b72-b3aa-ebc4fc72f3c2',
    platform: 'android',
    type: 'device connected'
}
```

This can happen when `preview` app or `playground` app are built incorrectly.
Fix the error above and show an update dialog on device in this case.