### PR TITLE
Bump preview app versions for playground and CLI

### DIFF
--- a/src/preview-app-versions.js
+++ b/src/preview-app-versions.js
@@ -1,12 +1,12 @@
 exports.fallbackPreviewVersions = {
 	"staging": {
 		"playground": {
-			"android": 32,
-			"ios": 20
+			"android": 33,
+			"ios": 21
 		},
 		"cli": {
-			"android": 32,
-			"ios": 20
+			"android": 33,
+			"ios": 21
 		},
 		"kinveyStudio": {
 			"android": 32,
@@ -15,12 +15,12 @@ exports.fallbackPreviewVersions = {
 	},
 	"uat": {
 		"playground": {
-			"android": 32,
-			"ios": 20
+			"android": 33,
+			"ios": 21
 		},
 		"cli": {
-			"android": 32,
-			"ios": 20
+			"android": 33,
+			"ios": 21
 		},
 		"kinveyStudio": {
 			"android": 32,
@@ -29,12 +29,12 @@ exports.fallbackPreviewVersions = {
 	},
 	"live": {
 		"playground": {
-			"android": 32,
-			"ios": 20
+			"android": 33,
+			"ios": 21
 		},
 		"cli": {
-			"android": 32,
-			"ios": 19
+			"android": 33,
+			"ios": 21
 		},
 		"kinveyStudio": {
 			"android": 32,


### PR DESCRIPTION
Bump minimum supported versions of the Preview app in Playground and CLI:

Android: 33 (1.16.0)
iOS: 21 (1.16.0)