### PR TITLE
fix: set PubNubInitialized to false on stop in order to ensure correct pubnub object will be created if initialize method is called after that

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nativescript-preview-sdk",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "description": "Handles the communication to the NativeScript Preview Apps",
     "main": "src/nativescript-preview-sdk",
     "typings": "src/nativescript-preview-sdk.d.ts",

--- a/src/services/messaging-service.ts
+++ b/src/services/messaging-service.ts
@@ -115,6 +115,7 @@ export class MessagingService {
 		this.pubNub.removeListener(this.pubNubListenerParams);
 		this.pubNub.unsubscribe(this.pubNubSubscribeParams);
 		this.pubNub.stop();
+		MessagingService.PubNubInitialized = false;
 		for (let uuid in this.connectedDevicesTimeouts) {
 			clearTimeout(this.connectedDevicesTimeouts[uuid]);
 		}


### PR DESCRIPTION
The following sequence of commands throw "Cannot read property 'removeListener' of undefined" error: initialize, stop, initialize, stop